### PR TITLE
Structs

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -573,6 +573,7 @@ static const int parse_prim_value(ast_t* ast, ast_value_t* value) {
 	case TOK_NEW: {
 		value->value_type = AST_VALUE_ALLOC_ARRAY;
 		READ_TOK;
+
 		PANIC_ON_NULL(value->data.alloc_array = malloc(sizeof(ast_alloc_t)), ast, ERROR_MEMORY);
 		ESCAPE_ON_NULL(parse_type_decl(ast, &value->data.alloc_array->elem_type, 0, 0, 0));
 		PANIC_ON_NULL(value->type.sub_types = malloc((value->type.sub_type_count = 1) * sizeof(typecheck_type_t)), ast, ERROR_MEMORY);

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -60,8 +60,7 @@ static const int std_itos(machine_reg_t* in, machine_reg_t* out) {
 	free(out->heap_alloc->init_stat);
 	free(out->heap_alloc->registers);
 	char output[50];
-	itoa((int)in->long_int, output, 10);
-	//sprintf(output, 50, "%" PRIi64, in->long_int);
+	sprintf(output, 50, "%" PRIi64, in->long_int);
 	uint8_t len = strlen(output);
 	out->heap_alloc->limit = len;
 	ESCAPE_ON_NULL(out->heap_alloc->registers = malloc(len * sizeof(machine_reg_t)));

--- a/src/type.h
+++ b/src/type.h
@@ -14,6 +14,7 @@ typedef struct typecheck_type {
 		TYPE_AUTO,
 		TYPE_NOTHING,
 		TYPE_TYPEARG,
+		TYPE_STRUCTURE,
 
 		TYPE_PRIMATIVE_BOOL,
 		TYPE_PRIMATIVE_CHAR,


### PR DESCRIPTION
I added some minimal support for structures in superforth's abstract syntax tree, however there are still quite a few things that have to be finished before structures can be fully implemented, and supported. There are a number of factors that ultimately contributed to my decision to merge:
- There was a **major** bug in the compilation process, caught *after* [this branch](https://github.com/TheRealMichaelWang/superforth/tree/structs) was created. The bug resulted in invalid insertions of long-to-float casts and failure to emit any operator instructions for numericals.
- In addition, a few other changes were implemented to the abstract syntax tree, mostly in an effort to reduce the size of the ast.
- The ast is bloated. It contains far more information than necessary to compile, especially in regards to types.
The next course of action would be to manually merge these branches together, and analyze the changes accordingly.