### PR TITLE
Fixed spelling errors

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -43,15 +43,15 @@ typedef struct ast_array_literal {
 	uint16_t element_count;
 } ast_array_literal_t;
 
-typedef struct ast_primative {
-	enum ast_primative_type {
-		AST_PRIMATIVE_BOOL,
-		AST_PRIMATIVE_CHAR,
-		AST_PRIMATIVE_LONG,
-		AST_PRIMATIVE_FLOAT
+typedef struct ast_primitive {
+	enum ast_primitive_type {
+		AST_PRIMITIVE_BOOL,
+		AST_PRIMITIVE_CHAR,
+		AST_PRIMITIVE_LONG,
+		AST_PRIMITIVE_FLOAT
 	} type;
 
-	union ast_primative_data
+	union ast_primitive_data
 	{
 		int bool_flag;
 		char character;
@@ -64,7 +64,7 @@ typedef struct ast_value {
 	typecheck_type_t type;
 
 	enum ast_value_type {
-		AST_VALUE_PRIMATIVE,
+		AST_VALUE_PRIMITIVE,
 		AST_VALUE_ALLOC_ARRAY,
 		AST_VALUE_ALLOC_RECORD,
 		AST_VALUE_ARRAY_LITERAL,
@@ -82,7 +82,7 @@ typedef struct ast_value {
 	} value_type;
 
 	union ast_value_data {
-		ast_primative_t primative;
+		ast_primitive_t primitive;
 		ast_alloc_t* alloc_array;
 		ast_record_proto_t* alloc_record;
 		ast_array_literal_t array_literal;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -34,8 +34,8 @@ static uint16_t allocate_value_regs(compiler_t* compiler, ast_value_t value, uin
 	uint16_t extra_regs = current_reg;
 	switch (value.value_type)
 	{
-	case AST_VALUE_PRIMATIVE:
-		memcpy(&compiler->target_machine->stack[compiler->current_constant], &value.data.primative.data, sizeof(uint64_t));
+	case AST_VALUE_PRIMITIVE:
+		memcpy(&compiler->target_machine->stack[compiler->current_constant], &value.data.primitive.data, sizeof(uint64_t));
 		compiler->eval_regs[value.id] = GLOB_REG(compiler->current_constant++);
 		compiler->move_eval[value.id] = 1;
 		return current_reg;

--- a/src/type.h
+++ b/src/type.h
@@ -15,10 +15,10 @@ typedef enum typecheck_base_type {
 	TYPE_NOTHING,
 	TYPE_TYPEARG,
 
-	TYPE_PRIMATIVE_BOOL,
-	TYPE_PRIMATIVE_CHAR,
-	TYPE_PRIMATIVE_LONG,
-	TYPE_PRIMATIVE_FLOAT,
+	TYPE_PRIMITIVE_BOOL,
+	TYPE_PRIMITIVE_CHAR,
+	TYPE_PRIMITIVE_LONG,
+	TYPE_PRIMITIVE_FLOAT,
 
 	TYPE_SUPER_ARRAY,
 	TYPE_SUPER_PROC,
@@ -34,10 +34,10 @@ typedef struct typecheck_type {
 
 #define IS_REF_TYPE(TYPE) (TYPE).type == TYPE_SUPER_ARRAY || (TYPE).type == TYPE_SUPER_RECORD
 
-static typecheck_type_t typecheck_int = { .type = TYPE_PRIMATIVE_LONG };
-static typecheck_type_t typecheck_float = { .type = TYPE_PRIMATIVE_FLOAT };
-static typecheck_type_t typecheck_char = { .type = TYPE_PRIMATIVE_CHAR };
-static typecheck_type_t typecheck_bool = { .type = TYPE_PRIMATIVE_BOOL };
+static typecheck_type_t typecheck_int = { .type = TYPE_PRIMITIVE_LONG };
+static typecheck_type_t typecheck_float = { .type = TYPE_PRIMITIVE_FLOAT };
+static typecheck_type_t typecheck_char = { .type = TYPE_PRIMITIVE_CHAR };
+static typecheck_type_t typecheck_bool = { .type = TYPE_PRIMITIVE_BOOL };
 static typecheck_type_t typecheck_array = { .type = TYPE_SUPER_ARRAY };
 
 void free_typecheck_type(typecheck_type_t* typecheck_type);


### PR DESCRIPTION
primative is actually spelled primitive