### PR TITLE
Type improvements1

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1285,11 +1285,9 @@ static void free_ast_record_proto(ast_record_proto_t* record_proto) {
 	for (uint_fast8_t i = 0; i < record_proto->property_count; i++)
 		free_typecheck_type(&record_proto->properties[i].type);
 	free(record_proto->properties);
-	if (record_proto->default_value_count) {
-		for (uint_fast16_t i = 0; i < record_proto->default_value_count; i++)
-			free_ast_value(&record_proto->default_values[i].value);
-		free(record_proto->default_values);
-	}
+	for (uint_fast16_t i = 0; i < record_proto->default_value_count; i++)
+		free_ast_value(&record_proto->default_values[i].value);
+	free(record_proto->default_values);
 	free(record_proto);
 }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -842,7 +842,7 @@ static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_t
 			if (var_info->is_readonly)
 				PANIC(ast_parser, ERROR_READONLY);
 			value->value_type = AST_VALUE_SET_VAR;
-			PANIC_ON_FAIL(value->data.set_var = malloc(sizeof(ast_set_var_t)), ast_parser, ERROR_UNDECLARED);
+			PANIC_ON_FAIL(value->data.set_var = malloc(sizeof(ast_set_var_t)), ast_parser, ERROR_MEMORY);
 			value->data.set_var->var_info = var_info;
 			ESCAPE_ON_FAIL(parse_expression(ast_parser, &value->data.set_var->set_value, &var_info->type, 0));
 			var_info->has_mutated = 1;

--- a/src/ast.c
+++ b/src/ast.c
@@ -1184,7 +1184,7 @@ static void free_ast_value(ast_value_t* value) {
 		for (uint_fast8_t i = 0; i < value->data.procedure->param_count; i++)
 			free_ast_var_info(&value->data.procedure->params[i].var_info);
 		free(value->data.procedure->params);
-		//free_ast_var_info(value->data.procedure->thisproc);
+		free(value->data.procedure->generic_arg_traces);
 		free(value->data.procedure->thisproc);
 		free_ast_code_block(&value->data.procedure->exec_block);
 		free(value->data.procedure);

--- a/src/ast.h
+++ b/src/ast.h
@@ -214,25 +214,16 @@ typedef struct ast_cond {
 	ast_cond_t* next_if_false;
 } ast_cond_t;
 
-typedef struct ast_proc_param {
-	ast_var_info_t var_info;
-	//uint16_t id;
-} ast_proc_param_t;
-
 typedef struct ast_proc {
 	typecheck_type_t* return_type;
-
-	ast_proc_param_t *params;
+	ast_var_info_t* params;
 	uint8_t param_count;
-
 	postproc_trace_status_t* generic_arg_traces;
-
 	uint16_t scope_size;
 	ast_var_info_t* thisproc;
-
 	ast_code_block_t exec_block;
 
-
+	uint16_t id;
 	int do_gc;
 } ast_proc_t;
 
@@ -290,7 +281,7 @@ typedef struct ast {
 	uint8_t record_count, allocated_records;
 
 	ast_primitive_t** primitives;
-	uint16_t constant_count, allocated_constants;
+	uint16_t constant_count, allocated_constants, proc_count;
 
 	uint32_t value_count, var_decl_count, proc_call_count;
 } ast_t;

--- a/src/ast.h
+++ b/src/ast.h
@@ -216,7 +216,7 @@ typedef struct ast_cond {
 
 typedef struct ast_proc_param {
 	ast_var_info_t var_info;
-	uint16_t id;
+	//uint16_t id;
 } ast_proc_param_t;
 
 typedef struct ast_proc {
@@ -224,10 +224,14 @@ typedef struct ast_proc {
 
 	ast_proc_param_t *params;
 	uint8_t param_count;
+
+	postproc_trace_status_t* generic_arg_traces;
+
 	uint16_t scope_size;
 	ast_var_info_t* thisproc;
 
 	ast_code_block_t exec_block;
+
 
 	int do_gc;
 } ast_proc_t;

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#ifndef max
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#endif // !max
+
+#endif // !COMMON_H

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -531,6 +531,7 @@ int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
 	PANIC_ON_FAIL(compiler->proc_generic_regs = malloc(ast->proc_call_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
 
 	PANIC_ON_FAIL(init_machine(target_machine, UINT16_MAX / 8, 1000), compiler, target_machine->last_err);
+
 	allocate_code_block_regs(compiler, ast->exec_block, 0);
 
 	PANIC_ON_FAIL(init_ins_builder(&compiler->ins_builder), compiler, ERROR_MEMORY);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -56,6 +56,9 @@ static uint16_t allocate_value_regs(compiler_t* compiler, ast_value_t value, uin
 	case AST_VALUE_PROC: {
 		compiler->var_regs[value.data.procedure->thisproc->id] = compiler->eval_regs[value.id] = GLOB_REG(compiler->ast->constant_count + compiler->current_global++);
 		compiler->move_eval[value.id] = 1;
+
+
+
 		for (uint_fast16_t i = 0; i < value.data.procedure->param_count; i++)
 			compiler->var_regs[value.data.procedure->params[i].var_info.id] = LOC_REG(i + 1);
 		allocate_code_block_regs(compiler, value.data.procedure->exec_block, value.data.procedure->param_count + value.type.type_id + 1);
@@ -525,8 +528,9 @@ int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
 	PANIC_ON_FAIL(compiler->move_eval = malloc(ast->value_count * sizeof(int)), compiler, ERROR_MEMORY);
 	PANIC_ON_FAIL(compiler->var_regs = malloc(ast->var_decl_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
 	PANIC_ON_FAIL(compiler->proc_call_offsets = malloc(ast->proc_call_count * sizeof(uint16_t)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->proc_generic_regs = malloc(ast->proc_call_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
 
-	PANIC_ON_FAIL(init_machine(target_machine, UINT16_MAX, 1000), compiler, target_machine->last_err);
+	PANIC_ON_FAIL(init_machine(target_machine, UINT16_MAX / 8, 1000), compiler, target_machine->last_err);
 	allocate_code_block_regs(compiler, ast->exec_block, 0);
 
 	PANIC_ON_FAIL(init_ins_builder(&compiler->ins_builder), compiler, ERROR_MEMORY);
@@ -541,6 +545,7 @@ int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
 	free(compiler->move_eval);
 	free(compiler->var_regs);
 	free(compiler->proc_call_offsets);
+	free(compiler->proc_generic_regs);
 
 	return 1;
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -57,11 +57,16 @@ static uint16_t allocate_value_regs(compiler_t* compiler, ast_value_t value, uin
 		compiler->var_regs[value.data.procedure->thisproc->id] = compiler->eval_regs[value.id] = GLOB_REG(compiler->ast->constant_count + compiler->current_global++);
 		compiler->move_eval[value.id] = 1;
 
-
+		uint16_t current_arg_reg = 1;
 
 		for (uint_fast16_t i = 0; i < value.data.procedure->param_count; i++)
-			compiler->var_regs[value.data.procedure->params[i].var_info.id] = LOC_REG(i + 1);
-		allocate_code_block_regs(compiler, value.data.procedure->exec_block, value.data.procedure->param_count + value.type.type_id + 1);
+			compiler->var_regs[value.data.procedure->params[i].id] = LOC_REG(current_arg_reg++);
+		
+		for (uint_fast8_t i = 0; i < value.type.type_id; i++)
+			if (value.data.procedure->generic_arg_traces[i] == POSTPROC_TRACE_DYNAMIC)
+				current_arg_reg++;
+
+		allocate_code_block_regs(compiler, value.data.procedure->exec_block, current_arg_reg);
 		return current_reg;
 	}
 	case AST_VALUE_VAR:
@@ -194,7 +199,7 @@ static void allocate_code_block_regs(compiler_t* compiler, ast_code_block_t code
       compiler_reg_t local_scratchpad = LOC_REG(0);
 			allocate_value_regs(compiler, code_block.instructions[i].data.value, current_reg, &local_scratchpad);
 			break;
-    }
+		}
 		case AST_STATEMENT_RETURN_VALUE: {
 			compiler_reg_t return_reg = LOC_REG(0);
 			allocate_value_regs(compiler, code_block.instructions[i].data.value, current_reg, &return_reg);
@@ -203,7 +208,7 @@ static void allocate_code_block_regs(compiler_t* compiler, ast_code_block_t code
 	}
 }
 
-#define TYPEARG_INFO_REG(TYPE)  LOC_REG(1 + proc->param_count + (TYPE).type_id)
+#define TYPEARG_INFO_REG(TYPE)  compiler->proc_generic_regs[proc->id][(TYPE).type_id]
 
 static int compile_code_block(compiler_t* compiler, ast_code_block_t code_block, ast_proc_t* proc, uint16_t continue_ip, uint16_t* break_jumps, uint8_t* break_jump_top);
 
@@ -273,6 +278,17 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 	}
 	case AST_VALUE_PROC: {
 		uint16_t start_ip = compiler->ins_builder.instruction_count;
+
+		if (value.type.type_id) {
+			PANIC_ON_FAIL(compiler->proc_generic_regs[value.data.procedure->id] = malloc(value.type.type_id * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
+			uint16_t gen_reg_begin = value.data.procedure->param_count + 1;
+			for (uint_fast8_t i = 0; i < value.type.type_id; i++)
+				if(value.data.procedure->generic_arg_traces[i] == POSTPROC_TRACE_DYNAMIC)
+					compiler->proc_generic_regs[value.data.procedure->id][i] = LOC_REG(gen_reg_begin++);
+		}
+		else
+			compiler->proc_generic_regs[value.data.procedure->id] = NULL;
+
 		EMIT_INS(INS1(COMPILER_OP_CODE_LABEL, compiler->eval_regs[value.id]));
 		EMIT_INS(INS0(COMPILER_OP_CODE_JUMP));
 		compiler->ins_builder.instructions[start_ip].regs[1] = GLOB_REG(compiler->ins_builder.instruction_count);
@@ -380,12 +396,13 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 		}
 
 		if (value.data.proc_call->procedure.type.type_id) {
+			uint16_t gen_arg_reg = value.data.proc_call->argument_count + 1 + compiler->proc_call_offsets[value.data.proc_call->id];
 			for (uint_fast8_t i = 0; i < value.data.proc_call->procedure.type.type_id; i++)
 				if (value.data.proc_call->procedure.type.sub_types[i].type == TYPE_ANY) {
 					if (value.data.proc_call->typeargs[i].type == TYPE_TYPEARG)
-						EMIT_INS(INS2(COMPILER_OP_CODE_MOVE, LOC_REG(compiler->proc_call_offsets[value.data.proc_call->id] + value.data.proc_call->argument_count + i + 1), TYPEARG_INFO_REG(value.data.set_prop->value.type)))
+						EMIT_INS(INS2(COMPILER_OP_CODE_MOVE, LOC_REG(gen_arg_reg++), TYPEARG_INFO_REG(value.data.set_prop->value.type)))
 					else
-						EMIT_INS(INS2(COMPILER_OP_CODE_SET, LOC_REG(compiler->proc_call_offsets[value.data.proc_call->id] + value.data.proc_call->argument_count + i + 1), GLOB_REG(IS_REF_TYPE(value.data.proc_call->typeargs[i]))));
+						EMIT_INS(INS2(COMPILER_OP_CODE_SET, LOC_REG(gen_arg_reg++), GLOB_REG(IS_REF_TYPE(value.data.proc_call->typeargs[i]))));
 				}
 		}
 
@@ -528,7 +545,7 @@ int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
 	PANIC_ON_FAIL(compiler->move_eval = malloc(ast->value_count * sizeof(int)), compiler, ERROR_MEMORY);
 	PANIC_ON_FAIL(compiler->var_regs = malloc(ast->var_decl_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
 	PANIC_ON_FAIL(compiler->proc_call_offsets = malloc(ast->proc_call_count * sizeof(uint16_t)), compiler, ERROR_MEMORY);
-	PANIC_ON_FAIL(compiler->proc_generic_regs = malloc(ast->proc_call_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->proc_generic_regs = malloc(ast->proc_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
 
 	PANIC_ON_FAIL(init_machine(target_machine, UINT16_MAX / 8, 1000), compiler, target_machine->last_err);
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -283,11 +283,9 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 			PANIC_ON_FAIL(compiler->proc_generic_regs[value.data.procedure->id] = malloc(value.type.type_id * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
 			uint16_t gen_reg_begin = value.data.procedure->param_count + 1;
 			for (uint_fast8_t i = 0; i < value.type.type_id; i++)
-				if(value.data.procedure->generic_arg_traces[i] == POSTPROC_TRACE_DYNAMIC)
+				if (value.data.procedure->generic_arg_traces[i] == POSTPROC_TRACE_DYNAMIC)
 					compiler->proc_generic_regs[value.data.procedure->id][i] = LOC_REG(gen_reg_begin++);
 		}
-		else
-			compiler->proc_generic_regs[value.data.procedure->id] = NULL;
 
 		EMIT_INS(INS1(COMPILER_OP_CODE_LABEL, compiler->eval_regs[value.id]));
 		EMIT_INS(INS0(COMPILER_OP_CODE_JUMP));
@@ -297,6 +295,9 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 		compile_code_block(compiler, value.data.procedure->exec_block, value.data.procedure, 0 , NULL, 0);
 		EMIT_INS(INS1(COMPILER_OP_CODE_ABORT, GLOB_REG(ERROR_UNRETURNED_FUNCTION)));
 		compiler->ins_builder.instructions[start_ip + 1].regs[0] = GLOB_REG(compiler->ins_builder.instruction_count);
+		
+		if (value.type.type_id)
+			free(compiler->proc_generic_regs[value.data.procedure->id]);
 		break;
 	}
 	case AST_VALUE_SET_VAR:

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -105,6 +105,7 @@ typedef struct compiler {
 	compiler_reg_t* var_regs;
 
 	uint16_t* proc_call_offsets;
+	compiler_reg_t** proc_generic_regs;
 
 	ast_t* ast;
 	machine_t* target_machine;

--- a/src/debug.c
+++ b/src/debug.c
@@ -361,11 +361,13 @@ const char* get_err_msg(error_t error) {
 }
 
 void print_error_trace(multi_scanner_t multi_scanner) {
-	for (uint_fast8_t i = 0; i < multi_scanner.current_file; i++)
-		printf("in %s: row %" PRIu32 ", col %"PRIu32 "\n", multi_scanner.file_paths[i], multi_scanner.scanners[i].row, multi_scanner.scanners[i].col);
-	printf("\t");
-	if (multi_scanner.last_tok.type == EOF) {
-		printf("EOF");
+	if (multi_scanner.current_file) {
+		for (uint_fast8_t i = 0; i < multi_scanner.current_file; i++)
+			printf("in %s: row %" PRIu32 ", col %"PRIu32 "\n", multi_scanner.file_paths[i], multi_scanner.scanners[i].row, multi_scanner.scanners[i].col);
+		printf("\t");
+	}
+	if (multi_scanner.last_tok.type == TOK_EOF) {
+		printf("Error Occured at EOF");
 	}
 	else {
 		for (uint_fast32_t i = 0; i < multi_scanner.last_tok.length; i++)

--- a/src/file.c
+++ b/src/file.c
@@ -27,7 +27,7 @@ static int write_ins(machine_ins_t ins, FILE* infile) {
 	return 1;
 }
 
-machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* instruction_count) {
+machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* instruction_count, uint16_t* constant_count) {
 	FILE* infile = fopen(path, "rb");
 	ESCAPE_ON_FAIL(infile);
 
@@ -42,6 +42,8 @@ machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* ins
 	machine_ins_t* instructions = malloc(*instruction_count * sizeof(machine_ins_t));
 	ESCAPE_ON_FAIL(instructions);
 
+	if (constant_count)
+		*constant_count = const_allocs;
 	for (uint_fast16_t i = 0; i < const_allocs; i++)
 		ESCAPE_ON_FAIL(fread(&machine->stack[i], sizeof(uint64_t), 1, infile));
 

--- a/src/file.c
+++ b/src/file.c
@@ -38,7 +38,7 @@ machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* ins
 	ESCAPE_ON_FAIL(fread(&const_allocs, sizeof(uint16_t), 1, infile));
 	ESCAPE_ON_FAIL(fread(instruction_count, sizeof(uint16_t), 1, infile));
 
-	ESCAPE_ON_FAIL(init_machine(machine, UINT16_MAX, 1000));
+	ESCAPE_ON_FAIL(init_machine(machine, UINT16_MAX / 8, 1000));
 	machine_ins_t* instructions = malloc(*instruction_count * sizeof(machine_ins_t));
 	ESCAPE_ON_FAIL(instructions);
 

--- a/src/file.h
+++ b/src/file.h
@@ -6,7 +6,7 @@
 #include "machine.h"
 #include "ast.h"
 
-machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* instruction_count);
+machine_ins_t* file_load_ins(const char* path, machine_t* machine, uint16_t* instruction_count, uint16_t* constant_count);
 int file_save_compiled(const char* path, ast_t* ast, machine_t* machine, machine_ins_t* instructions, uint16_t instruction_count);
 
 char* file_read_source(const char* path);

--- a/src/postproc.c
+++ b/src/postproc.c
@@ -486,14 +486,14 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		int* new_shared_globals = malloc(ast_parser->global_count * sizeof(int));
 		PANIC_ON_FAIL(new_shared_globals, ast_parser, ERROR_MEMORY);
 		memcpy(new_shared_globals, ast_parser->shared_globals, ast_parser->global_count * sizeof(int));
-		postproc_trace_status_t* typearg_traces = malloc(value->type.type_id * sizeof(postproc_trace_status_t));
-		PANIC_ON_FAIL(typearg_traces, ast_parser, ERROR_MEMORY);
+		value->data.procedure->generic_arg_traces = malloc(value->type.type_id * sizeof(postproc_trace_status_t));
+		PANIC_ON_FAIL(value->data.procedure->generic_arg_traces, ast_parser, ERROR_MEMORY);
 
 		for (uint_fast8_t i = 0; i < value->type.type_id; i++) {
 			if (value->type.sub_types[i].type == TYPE_ANY)
-				typearg_traces[i] = POSTPROC_TRACE_DYNAMIC;
+				value->data.procedure->generic_arg_traces[i] = POSTPROC_TRACE_DYNAMIC;
 			else
-				typearg_traces[i] = GET_TYPE_TRACE(value->type.sub_types[i]);
+				value->data.procedure->generic_arg_traces[i] = GET_TYPE_TRACE(value->type.sub_types[i]);
 		}
 		
 		for (uint_fast8_t i = 0; i < value->data.procedure->param_count; i++) {
@@ -506,12 +506,12 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		}
 
 		value->data.procedure->do_gc = 0;
-		ESCAPE_ON_FAIL(ast_postproc_code_block(ast_parser, &value->data.procedure->exec_block, typearg_traces, new_global_stats, new_local_stats, value->data.procedure->scope_size, new_shared_globals, new_shared_locals, 0, value->data.procedure));
+		ESCAPE_ON_FAIL(ast_postproc_code_block(ast_parser, &value->data.procedure->exec_block, value->data.procedure->generic_arg_traces, new_global_stats, new_local_stats, value->data.procedure->scope_size, new_shared_globals, new_shared_locals, 0, value->data.procedure));
+
 		free(new_local_stats);
 		free(new_global_stats);
 		free(new_shared_locals);
 		free(new_shared_globals);
-		free(typearg_traces);
 		break;
 	}
 	case AST_VALUE_VAR:

--- a/src/postproc.c
+++ b/src/postproc.c
@@ -497,12 +497,12 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		}
 		
 		for (uint_fast8_t i = 0; i < value->data.procedure->param_count; i++) {
-			if (value->data.procedure->params[i].var_info.type.type == TYPE_TYPEARG)
-				new_local_stats[value->data.procedure->params[i].var_info.scope_id] = POSTPROC_GC_EXTERN_DYNAMIC;
-			else if (IS_REF_TYPE(value->data.procedure->params[i].var_info.type))
-				new_local_stats[value->data.procedure->params[i].var_info.scope_id] = POSTPROC_GC_EXTERN_ALLOC;
+			if (value->data.procedure->params[i].type.type == TYPE_TYPEARG)
+				new_local_stats[value->data.procedure->params[i].scope_id] = POSTPROC_GC_EXTERN_DYNAMIC;
+			else if (IS_REF_TYPE(value->data.procedure->params[i].type))
+				new_local_stats[value->data.procedure->params[i].scope_id] = POSTPROC_GC_EXTERN_ALLOC;
 			else
-				new_local_stats[value->data.procedure->params[i].var_info.scope_id] = POSTPROC_GC_NONE;
+				new_local_stats[value->data.procedure->params[i].scope_id] = POSTPROC_GC_NONE;
 		}
 
 		value->data.procedure->do_gc = 0;

--- a/src/source.c
+++ b/src/source.c
@@ -6,7 +6,7 @@
 #include "machine.h"
 #include "ast.h"
 #include "file.h"
-#include "stdlib.h"
+#include "stdlibf.h"
 #include "debug.h"
 
 #define ABORT(MSG) {printf MSG ; exit(EXIT_FAILURE);}
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
 		machine_t machine;
 		uint16_t instruction_count;
 		EXPECT_FLAG("-s");
-		machine_ins_t* instructions = file_load_ins(READ_ARG, &machine, &instruction_count);
+		machine_ins_t* instructions = file_load_ins(READ_ARG, &machine, &instruction_count, NULL);
 		if (!instructions)
 			ABORT(("Unable to load binaries from file.\n"));
 		if (!strcmp(op_flag, "-r")) {

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -7,7 +7,7 @@
 #include <time.h>
 #include "error.h"
 #include "ffi.h"
-#include "stdlib.h"
+#include "stdlibf.h"
 
 static char* read_str_from_heap_alloc(heap_alloc_t* heap_alloc) {
 	char* buffer = malloc(heap_alloc->limit + 1);

--- a/src/stdlibf.h
+++ b/src/stdlibf.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef STDLIB_H
+#define STDLIB_H
+
+#include "machine.h"
+
+void install_stdlib(machine_t* machine);
+
+#endif // !STDLIB_H

--- a/src/type.c
+++ b/src/type.c
@@ -68,8 +68,12 @@ int typecheck_compatible(ast_parser_t* ast_parser, typecheck_type_t* target_type
 
 		if (target_type->type == TYPE_SUPER_PROC) {
 			ESCAPE_ON_FAIL(target_type->sub_type_count == match_type.sub_type_count);
-			for (uint_fast8_t i = 0; i < target_type->sub_type_count; i++)
-				ESCAPE_ON_FAIL(typecheck_compatible(ast_parser, &match_type.sub_types[i], target_type->sub_types[i]));
+			for (uint_fast8_t i = 0; i < target_type->sub_type_count; i++) {
+				if (i == target_type->type_id)
+					ESCAPE_ON_FAIL(typecheck_compatible(ast_parser, &target_type->sub_types[i], match_type.sub_types[i]))
+				else
+					ESCAPE_ON_FAIL(typecheck_compatible(ast_parser, &match_type.sub_types[i], target_type->sub_types[i]));
+			}
 		}
 		else if (target_type->type >= TYPE_SUPER_ARRAY) {
 			ESCAPE_ON_FAIL(target_type->sub_type_count == match_type.sub_type_count);

--- a/src/type.c
+++ b/src/type.c
@@ -27,17 +27,23 @@ int copy_typecheck_type(typecheck_type_t* dest, typecheck_type_t src) {
 	return 1;
 }
 
-int typecheck_compatible(ast_t* ast, typecheck_type_t* target_type, typecheck_type_t match_type) {
+int typecheck_compatible(ast_parser_t* ast_parser, typecheck_type_t* target_type, typecheck_type_t match_type) {
 	if (match_type.type == TYPE_ANY)
 		return 1;
 	else if (target_type->type == TYPE_AUTO)
 		return copy_typecheck_type(target_type, match_type);
 	else {
-		ESCAPE_ON_FAIL(target_type->type == match_type.type);
+		if (target_type->type != match_type.type) {
+			if (target_type->type == TYPE_TYPEARG)
+				return typecheck_compatible(ast_parser, devolve_type_from_generic(ast_parser, target_type), match_type);
+			else
+				return 0;
+		}
+
 		if (target_type->type == TYPE_TYPEARG)
 			return target_type->type_id == match_type.type_id;
 		if (target_type->type == TYPE_SUPER_RECORD && target_type->type_id != match_type.type_id) {
-			ast_record_proto_t* record_proto = ast->record_protos[target_type->type_id];
+			ast_record_proto_t* record_proto = ast_parser->ast->record_protos[target_type->type_id];
 
 			typecheck_type_t current_rec_type;
 			ESCAPE_ON_FAIL(copy_typecheck_type(&current_rec_type, *target_type));
@@ -52,9 +58,9 @@ int typecheck_compatible(ast_t* ast, typecheck_type_t* target_type, typecheck_ty
 				ESCAPE_ON_FAIL(typeargs_substitute(current_rec_type.sub_types, &next_rec_type));
 				free_typecheck_type(&current_rec_type);
 				current_rec_type = next_rec_type;
-				record_proto = ast->record_protos[current_rec_type.type_id];
+				record_proto = ast_parser->ast->record_protos[current_rec_type.type_id];
 			} while (current_rec_type.type_id != match_type.type_id);
-			res = typecheck_compatible(ast, &current_rec_type, match_type);
+			res = typecheck_compatible(ast_parser, &current_rec_type, match_type);
 		typecheck_record_failed:
 			free_typecheck_type(&current_rec_type);
 			return res;
@@ -63,19 +69,25 @@ int typecheck_compatible(ast_t* ast, typecheck_type_t* target_type, typecheck_ty
 		if (target_type->type == TYPE_SUPER_PROC) {
 			ESCAPE_ON_FAIL(target_type->sub_type_count == match_type.sub_type_count);
 			for (uint_fast8_t i = 0; i < target_type->sub_type_count; i++)
-				ESCAPE_ON_FAIL(typecheck_compatible(ast, &match_type.sub_types[i], target_type->sub_types[i]));
+				ESCAPE_ON_FAIL(typecheck_compatible(ast_parser, &match_type.sub_types[i], target_type->sub_types[i]));
 		}
 		else if (target_type->type >= TYPE_SUPER_ARRAY) {
 			ESCAPE_ON_FAIL(target_type->sub_type_count == match_type.sub_type_count);
 			for (uint_fast8_t i = 0; i < target_type->sub_type_count; i++)
-				ESCAPE_ON_FAIL(typecheck_compatible(ast, &target_type->sub_types[i], match_type.sub_types[i]));
+				ESCAPE_ON_FAIL(typecheck_compatible(ast_parser, &target_type->sub_types[i], match_type.sub_types[i]));
 		}
 		return 1;
 	}
 }
 
-int typecheck_lowest_common_type(ast_t* ast, typecheck_type_t a, typecheck_type_t b, typecheck_type_t* result) {
+int typecheck_lowest_common_type(ast_parser_t* ast_parser, typecheck_type_t a, typecheck_type_t b, typecheck_type_t* result) {
 	if (a.type != b.type) {
+		a = *devolve_type_from_generic(ast_parser, &a);
+		b = *devolve_type_from_generic(ast_parser, &b);
+
+		if (a.type == b.type)
+			return typecheck_lowest_common_type(ast_parser, a, b, result);
+
 		*result = typecheck_any;
 		return 1;
 	}
@@ -87,19 +99,19 @@ int typecheck_lowest_common_type(ast_t* ast, typecheck_type_t a, typecheck_type_
 			ESCAPE_ON_FAIL(copy_typecheck_type(&a_rec_type, a));
 			
 			for (;;) {
-				ast_record_proto_t* record_a = ast->record_protos[a_rec_type.type_id];
+				ast_record_proto_t* record_a = ast_parser->ast->record_protos[a_rec_type.type_id];
 
 				typecheck_type_t b_rec_type;
 				ESCAPE_ON_FAIL(copy_typecheck_type(&b_rec_type, b));
 				for (;;) {
-					ast_record_proto_t* record_b = ast->record_protos[b_rec_type.type_id];
+					ast_record_proto_t* record_b = ast_parser->ast->record_protos[b_rec_type.type_id];
 					
 					if (record_a == record_b) {
 						common_type.type_id = record_a->id;
 						common_type.sub_type_count = record_a->generic_arguments;
 						ESCAPE_ON_FAIL(common_type.sub_types = malloc(common_type.sub_type_count * sizeof(typecheck_type_t)));
 						for (uint_fast8_t i = 0; i < a_rec_type.sub_type_count; i++)
-							ESCAPE_ON_FAIL(typecheck_lowest_common_type(ast, a.sub_types[i], b.sub_types[i], &common_type.sub_types[i]));
+							ESCAPE_ON_FAIL(typecheck_lowest_common_type(ast_parser, a.sub_types[i], b.sub_types[i], &common_type.sub_types[i]));
 						free_typecheck_type(&a_rec_type);
 						free_typecheck_type(&b_rec_type);
 						*result = common_type;
@@ -151,7 +163,7 @@ int typecheck_lowest_common_type(ast_t* ast, typecheck_type_t a, typecheck_type_
 		ESCAPE_ON_FAIL(common_type.sub_types = malloc(common_type.sub_type_count * sizeof(typecheck_type_t)));
 
 		for (uint_fast8_t i = 0; i < common_type.sub_type_count; i++)
-			ESCAPE_ON_FAIL(typecheck_lowest_common_type(ast, a.sub_types[i], b.sub_types[i], &common_type.sub_types[i]));
+			ESCAPE_ON_FAIL(typecheck_lowest_common_type(ast_parser, a.sub_types[i], b.sub_types[i], &common_type.sub_types[i]));
 	}
 	*result = common_type;
 	return 1;
@@ -167,20 +179,6 @@ int typecheck_has_type(typecheck_type_t type, typecheck_base_type_t base_type) {
 	return 0;
 }
 
-int typeargs_replace_generics(typecheck_type_t* input_type_reqs, typecheck_type_t* proto_type, int req_static_types) {
-	if (proto_type->type == TYPE_TYPEARG) {
-		if (input_type_reqs[proto_type->type_id].type != TYPE_ANY)
-			ESCAPE_ON_FAIL(copy_typecheck_type(proto_type, input_type_reqs[proto_type->type_id]))
-		else
-			ESCAPE_ON_FAIL(!req_static_types);
-	}
-	else if (proto_type->type >= TYPE_SUPER_ARRAY)
-		for (uint_fast8_t i = 0; i < proto_type->sub_type_count; i++)
-			ESCAPE_ON_FAIL(typeargs_replace_generics(input_type_reqs, &proto_type->sub_types[i], req_static_types));
-
-	return 1;
-}
-
 int typeargs_substitute(typecheck_type_t* input_typeargs, typecheck_type_t* proto_type) {
 	if (proto_type->type == TYPE_TYPEARG)
 		ESCAPE_ON_FAIL(copy_typecheck_type(proto_type, input_typeargs[proto_type->type_id]))
@@ -189,4 +187,25 @@ int typeargs_substitute(typecheck_type_t* input_typeargs, typecheck_type_t* prot
 			ESCAPE_ON_FAIL(typeargs_substitute(input_typeargs, &proto_type->sub_types[i]));
 	}
 	return 1;
+}
+
+ast_generic_cache_entry_t* generic_from_type(ast_parser_t* ast_parser, typecheck_type_t type) {
+	if (type.type != TYPE_TYPEARG)
+		return NULL;
+	ast_parser_frame_t* current_frame = &ast_parser->frames[ast_parser->current_frame - 1];
+	while (current_frame->parent_frame)
+		current_frame = current_frame->parent_frame;
+	if (current_frame->generic_count <= type.type_id)
+		return NULL;
+	return &current_frame->generics[type.type_id];
+}
+
+typecheck_type_t* devolve_type_from_generic(ast_parser_t* ast_parser, typecheck_type_t* type) {
+	if (type->type == TYPE_TYPEARG) {
+		ast_generic_cache_entry_t* generic = generic_from_type(ast_parser, *type);
+		ESCAPE_ON_FAIL(generic);
+		if (generic->req_type)
+			return generic->req_type;
+	}
+	return type;
 }

--- a/src/type.h
+++ b/src/type.h
@@ -8,7 +8,9 @@
 #define TYPE_MAX_SUBTYPES 100
 
 typedef struct typecheck_type typecheck_type_t;
-typedef struct ast ast_t;
+typedef struct ast_parser ast_parser_t;
+typedef struct ast_generic_cache_entry ast_generic_cache_entry_t;
+typedef struct ast_record_proto ast_record_proto_t;
 
 typedef enum typecheck_base_type {
 	TYPE_AUTO,
@@ -46,11 +48,13 @@ static typecheck_type_t typecheck_any = { .type = TYPE_ANY };
 void free_typecheck_type(typecheck_type_t* typecheck_type);
 int copy_typecheck_type(typecheck_type_t* dest, typecheck_type_t src);
 
-int typecheck_compatible(ast_t* ast, typecheck_type_t* target_type, typecheck_type_t match_type);
+int typecheck_compatible(ast_parser_t* ast_parser, typecheck_type_t* target_type, typecheck_type_t match_type);
 
 int typecheck_has_type(typecheck_type_t type, typecheck_base_type_t base_type);
 
 int typeargs_substitute(typecheck_type_t* input_typeargs, typecheck_type_t* proto_type);
-int typeargs_replace_generics(typecheck_type_t* input_type_reqs, typecheck_type_t* proto_type, int req_static_types);
-int typecheck_lowest_common_type(ast_t* ast, typecheck_type_t a, typecheck_type_t b, typecheck_type_t* result);
+int typecheck_lowest_common_type(ast_parser_t* ast_parser, typecheck_type_t a, typecheck_type_t b, typecheck_type_t* result);
+
+ast_generic_cache_entry_t* generic_from_type(ast_parser_t* ast_parser, typecheck_type_t type);
+typecheck_type_t* devolve_type_from_generic(ast_parser_t* ast_parser, typecheck_type_t* type);
 #endif // !TYPE


### PR DESCRIPTION
- Improved type checking
  - Fixed many type-safety related bugs and quirks with procedures.
  - Reworked the way generics are type checked. Rather than being completely replaced by the generic's required type, generics fall back to their required type only when the first round of type checking fails.
    - Also has the benefit of ensuring the flow of data in a type-safe manner.
- Made performance improvements that weren't possible previously
  - Fewer silent arguments are used to pass in generic information. When the user implements a required type for a generic, garbage-collection information doesn't have to be determined at runtime anymore.