### PR TITLE
Made the Compiler Memory Safe

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -757,7 +757,6 @@ static int parse_code_block(ast_parser_t* ast_parser, ast_code_block_t* code_blo
 }
 
 static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_type_t* type) {
-	value->from_var = 0;
 	switch (LAST_TOK.type) {
 	case TOK_NUMERICAL:
 	case TOK_CHAR:
@@ -888,7 +887,6 @@ static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_t
 	}
 	case TOK_IDENTIFIER: {
 		ast_var_info_t* var_info = ast_parser_find_var(ast_parser, hash_s(LAST_TOK.str, LAST_TOK.length));
-		value->from_var = 1;
 		PANIC_ON_FAIL(var_info, ast_parser, ERROR_UNDECLARED);
 		TYPE_COPY(&value->type, var_info->type);
 
@@ -1086,7 +1084,6 @@ static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_t
 
 			TYPE_COMP(&array_val.type, typecheck_array);
 
-			value->from_var = array_val.from_var;
 			ESCAPE_ON_FAIL(parse_expression(ast_parser, &index_val, &typecheck_int, 0, 0));
 			if (index_val.value_type == AST_VALUE_PRIMITIVE && index_val.data.primitive->data.long_int < 0)
 				PANIC(ast_parser, ERROR_INDEX_OUT_OF_RANGE);
@@ -1116,7 +1113,6 @@ static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_t
 			PANIC_ON_FAIL(record_val.type.type == TYPE_SUPER_RECORD, ast_parser, ERROR_UNEXPECTED_TYPE);
 			free_typecheck_type(ast_parser->safe_gc, &value->type);
 
-			value->from_var = record_val.from_var;
 			ast_record_prop_t* property;
 			MATCH_TOK(TOK_IDENTIFIER);
 			uint64_t id = hash_s(LAST_TOK.str, LAST_TOK.length);
@@ -1149,7 +1145,6 @@ static int parse_value(ast_parser_t* ast_parser, ast_value_t* value, typecheck_t
 			PANIC_ON_FAIL(proc_val.type.type == TYPE_SUPER_PROC, ast_parser, ERROR_UNEXPECTED_TYPE);
 			free_typecheck_type(ast_parser->safe_gc, &value->type);
 
-			value->from_var = 0;
 			value->value_type = AST_VALUE_PROC_CALL;
 			PANIC_ON_FAIL(value->data.proc_call = safe_malloc(ast_parser->safe_gc, sizeof(ast_call_proc_t)), ast_parser, ERROR_MEMORY);
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -26,6 +26,7 @@ typedef struct ast_record_prop ast_record_prop_t;
 typedef struct ast_get_prop ast_get_prop_t;
 typedef struct ast_set_prop ast_set_prop_t;
 typedef struct ast_type_op ast_type_op_t;
+typedef struct ast_alloc_record_init_value ast_alloc_record_init_value_t;
 
 typedef struct ast_var_info {
 	uint32_t id;
@@ -42,11 +43,6 @@ typedef struct ast_array_literal {
 
 	postproc_trace_status_t children_trace;
 } ast_array_literal_t;
-
-typedef struct ast_alloc_record_init_value {
-	ast_record_prop_t* property;
-	ast_value_t* value;
-} ast_alloc_record_init_value_t;
 
 typedef struct ast_alloc_record {
 	ast_record_proto_t* proto;
@@ -243,6 +239,11 @@ typedef struct ast_record_prop {
 	int must_init;
 } ast_record_prop_t;
 
+typedef struct ast_alloc_record_init_value {
+	ast_record_prop_t* property;
+	ast_value_t value;
+} ast_alloc_record_init_value_t;
+
 typedef struct ast_record_proto {
 	uint64_t hash_id;
 
@@ -252,10 +253,7 @@ typedef struct ast_record_proto {
 	typecheck_type_t* generic_req_types;
 	uint8_t generic_arguments;
 
-	struct ast_record_proto_init_value {
-		ast_record_prop_t* property;
-		ast_value_t value;
-	}*default_values;
+	ast_alloc_record_init_value_t*default_values;
 
 	enum ast_record_use_reqs {
 		AST_RECORD_USE_ALL,

--- a/src/ast.h
+++ b/src/ast.h
@@ -46,7 +46,6 @@ typedef struct ast_array_literal {
 typedef struct ast_alloc_record_init_value {
 	ast_record_prop_t* property;
 	ast_value_t* value;
-	int free_val;
 } ast_alloc_record_init_value_t;
 
 typedef struct ast_alloc_record {
@@ -330,15 +329,15 @@ typedef struct ast_parser {
 	postproc_gc_status_t* global_gc_stats;
 	int* shared_globals;
 
+	safe_gc_t* safe_gc;
 	error_t last_err;
 } ast_parser_t;
 
 int ast_record_sub_prop_type(ast_parser_t* ast_parser, typecheck_type_t record_type, uint64_t id, typecheck_type_t* out_type);
 
-int init_ast_parser(ast_parser_t* ast_parser, const char* source);
+int init_ast_parser(ast_parser_t* ast_parser, safe_gc_t* safe_gc, const char* source);
 void free_ast_parser(ast_parser_t* ast_parser);
 
 int init_ast(ast_t* ast, ast_parser_t* ast_parser);
-void free_ast(ast_t* ast);
 
 #endif // !AST_H

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -12,15 +12,16 @@
 
 #define EMIT_INS(INS) PANIC_ON_FAIL(ins_builder_append_ins(&compiler->ins_builder, INS), compiler, ERROR_MEMORY)
 
-int init_ins_builder(ins_builder_t* ins_builder) {
-	ESCAPE_ON_FAIL(ins_builder->instructions = malloc((ins_builder->alloced_ins = 64) * sizeof(compiler_ins_t)));
+int init_ins_builder(ins_builder_t* ins_builder, safe_gc_t* safe_gc) {
+	ins_builder->safe_gc = safe_gc;
+	ESCAPE_ON_FAIL(ins_builder->instructions = safe_malloc(safe_gc, (ins_builder->alloced_ins = 64) * sizeof(compiler_ins_t)));
 	ins_builder->instruction_count = 0;
 	return 1;
 }
 
 int ins_builder_append_ins(ins_builder_t* ins_builder, compiler_ins_t ins) {
 	if (ins_builder->instruction_count == ins_builder->alloced_ins) {
-		compiler_ins_t* new_ins = realloc(ins_builder->instructions, (ins_builder->alloced_ins *= 2) * sizeof(compiler_ins_t));
+		compiler_ins_t* new_ins = safe_realloc(ins_builder->safe_gc, ins_builder->instructions, (ins_builder->alloced_ins *= 2) * sizeof(compiler_ins_t));
 		ESCAPE_ON_FAIL(new_ins);
 		ins_builder->instructions = new_ins;
 	}
@@ -289,7 +290,7 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 		uint16_t start_ip = compiler->ins_builder.instruction_count;
 
 		if (value.type.type_id) {
-			PANIC_ON_FAIL(compiler->proc_generic_regs[value.data.procedure->id] = malloc(value.type.type_id * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
+			PANIC_ON_FAIL(compiler->proc_generic_regs[value.data.procedure->id] = safe_malloc(compiler->safe_gc, value.type.type_id * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
 			uint16_t gen_reg_begin = value.data.procedure->param_count + 1;
 			for (uint_fast8_t i = 0; i < value.type.type_id; i++)
 				if (value.data.procedure->generic_arg_traces[i] == POSTPROC_TRACE_DYNAMIC)
@@ -308,7 +309,7 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 		compiler->ins_builder.instructions[start_ip + 1].regs[0] = GLOB_REG(compiler->ins_builder.instruction_count);
 		
 		if (value.type.type_id)
-			free(compiler->proc_generic_regs[value.data.procedure->id]);
+			safe_free(compiler->safe_gc, compiler->proc_generic_regs[value.data.procedure->id]);
 		break;
 	}
 	case AST_VALUE_SET_VAR:
@@ -510,7 +511,7 @@ static int compile_conditional(compiler_t* compiler, ast_cond_t* conditional, as
 				escape_jump_count++;
 			count_cond = count_cond->next_if_false;
 		}
-		uint16_t* escape_jumps = malloc(escape_jump_count * sizeof(uint16_t));
+		uint16_t* escape_jumps = safe_malloc(compiler->safe_gc, escape_jump_count * sizeof(uint16_t));
 		PANIC_ON_FAIL(escape_jumps, compiler, ERROR_MEMORY);
 		uint16_t current_escape_jump = 0;
 		while (conditional) {
@@ -533,7 +534,7 @@ static int compile_conditional(compiler_t* compiler, ast_cond_t* conditional, as
 		}
 		for (uint_fast16_t i = 0; i < escape_jump_count; i++)
 			compiler->ins_builder.instructions[escape_jumps[i]].regs[0] = GLOB_REG(compiler->ins_builder.instruction_count);
-		free(escape_jumps);
+		safe_free(compiler->safe_gc, escape_jumps);
 	}
 	return 1;
 }
@@ -592,23 +593,24 @@ static int compile_code_block(compiler_t* compiler, ast_code_block_t code_block,
 	return 1;
 }
 
-int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
+int compile(compiler_t* compiler, safe_gc_t* safe_gc, machine_t* target_machine, ast_t* ast) {
 	compiler->target_machine = target_machine;
+	compiler->safe_gc = safe_gc;
 	compiler->ast = ast;
 	compiler->last_err = ERROR_NONE;
 	compiler->current_global = 0;
 
-	PANIC_ON_FAIL(compiler->eval_regs = malloc(ast->value_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
-	PANIC_ON_FAIL(compiler->move_eval = malloc(ast->value_count * sizeof(int)), compiler, ERROR_MEMORY);
-	PANIC_ON_FAIL(compiler->var_regs = malloc(ast->var_decl_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
-	PANIC_ON_FAIL(compiler->proc_call_offsets = malloc(ast->proc_call_count * sizeof(uint16_t)), compiler, ERROR_MEMORY);
-	PANIC_ON_FAIL(compiler->proc_generic_regs = malloc(ast->proc_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->eval_regs = safe_malloc(safe_gc, ast->value_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->move_eval = safe_malloc(safe_gc, ast->value_count * sizeof(int)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->var_regs = safe_malloc(safe_gc, ast->var_decl_count * sizeof(compiler_reg_t)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->proc_call_offsets = safe_malloc(safe_gc, ast->proc_call_count * sizeof(uint16_t)), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(compiler->proc_generic_regs = safe_malloc(safe_gc, ast->proc_count * sizeof(compiler_reg_t*)), compiler, ERROR_MEMORY);
 
 	PANIC_ON_FAIL(init_machine(target_machine, UINT16_MAX / 8, 1000, TYPE_SUPER_RECORD + ast->record_count), compiler, target_machine->last_err);
 
 	allocate_code_block_regs(compiler, ast->exec_block, 0);
 
-	PANIC_ON_FAIL(init_ins_builder(&compiler->ins_builder), compiler, ERROR_MEMORY);
+	PANIC_ON_FAIL(init_ins_builder(&compiler->ins_builder, safe_gc), compiler, ERROR_MEMORY);
 	
 	EMIT_INS(INS1(COMPILER_OP_CODE_STACK_OFFSET, GLOB_REG(compiler->ast->constant_count + compiler->current_global)));
 	EMIT_INS(INS0(COMPILER_OP_CODE_GC_NEW_FRAME));
@@ -616,11 +618,11 @@ int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast) {
 	EMIT_INS(INS0(COMPILER_OP_CODE_GC_CLEAN));
 	EMIT_INS(INS1(COMPILER_OP_CODE_ABORT, GLOB_REG(ERROR_NONE)));
 
-	free(compiler->eval_regs);
-	free(compiler->move_eval);
-	free(compiler->var_regs);
-	free(compiler->proc_call_offsets);
-	free(compiler->proc_generic_regs);
+	safe_free(safe_gc, compiler->eval_regs);
+	safe_free(safe_gc, compiler->move_eval);
+	safe_free(safe_gc, compiler->var_regs);
+	safe_free(safe_gc, compiler->proc_call_offsets);
+	safe_free(safe_gc, compiler->proc_generic_regs);
 
 	return 1;
 }
@@ -810,7 +812,7 @@ static int compile_type_to_machine(machine_type_sig_t* out_sig, typecheck_type_t
 
 	if (HAS_SUBTYPES(type)) {
 		if (type.sub_type_count) {
-			PANIC_ON_FAIL(out_sig->sub_types = malloc(type.sub_type_count * sizeof(machine_type_sig_t)), compiler, ERROR_MEMORY);
+			PANIC_ON_FAIL(out_sig->sub_types = safe_transfer_malloc(compiler->safe_gc, type.sub_type_count * sizeof(machine_type_sig_t)), compiler, ERROR_MEMORY);
 			for (uint_fast8_t i = 0; i < type.sub_type_count; i++)
 				ESCAPE_ON_FAIL(compile_type_to_machine(&out_sig->sub_types[i], type.sub_types[i],compiler, proc));
 		}

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -51,7 +51,7 @@ static uint16_t allocate_value_regs(compiler_t* compiler, ast_value_t value, uin
 		break;
 	case AST_VALUE_ALLOC_RECORD: {
 		for (uint_fast16_t i = 0; i < value.data.alloc_record.init_value_count; i++)
-			allocate_value_regs(compiler, *value.data.alloc_record.init_values[i].value, current_reg + 1, NULL);
+			allocate_value_regs(compiler, value.data.alloc_record.init_values[i].value, current_reg + 1, NULL);
 		break;
 	}
 	case AST_VALUE_PROC: {
@@ -262,12 +262,11 @@ static int compile_value(compiler_t* compiler, ast_value_t value, ast_proc_t* pr
 
 		uint16_t sig_id = compiler->target_machine->defined_sig_count;
 		ESCAPE_ON_FAIL(compiler_define_typesig(compiler, proc, value.type));
-
 		EMIT_INS(INS2(COMPILER_OP_CODE_CONFIG_TYPESIG, compiler->eval_regs[value.id], GLOB_REG(sig_id)));
 
 		for (uint_fast16_t i = 0; i < value.data.alloc_record.init_value_count; i++) {
-			ESCAPE_ON_FAIL(compile_value(compiler, *value.data.alloc_record.init_values[i].value, proc));
-			EMIT_INS(INS3(COMPILER_OP_CODE_STORE_ALLOC_I, compiler->eval_regs[value.id], compiler->eval_regs[value.data.alloc_record.init_values[i].value->id], GLOB_REG(value.data.alloc_record.init_values[i].property->id)));
+			ESCAPE_ON_FAIL(compile_value(compiler, value.data.alloc_record.init_values[i].value, proc));
+			EMIT_INS(INS3(COMPILER_OP_CODE_STORE_ALLOC_I, compiler->eval_regs[value.id], compiler->eval_regs[value.data.alloc_record.init_values[i].value.id], GLOB_REG(value.data.alloc_record.init_values[i].property->id)));
 		}
 
 		if (value.data.alloc_record.proto->do_gc) {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -128,11 +128,13 @@ static uint16_t allocate_value_regs(compiler_t* compiler, ast_value_t value, uin
 	case AST_VALUE_PROC_CALL: {
 		compiler->eval_regs[value.id] = LOC_REG(compiler->proc_call_offsets[value.data.proc_call->id] = extra_regs++);
 		compiler->move_eval[value.id] = !(value.type.type == TYPE_NOTHING || !target_reg || (target_reg->offset && target_reg->reg == current_reg));
+
 		for (uint_fast8_t i = 0; i < value.data.proc_call->argument_count; i++) {
 			compiler_reg_t arg_reg = LOC_REG(extra_regs);
 			allocate_value_regs(compiler, value.data.proc_call->arguments[i], extra_regs++, &arg_reg);
 		}
 		allocate_value_regs(compiler, value.data.proc_call->procedure, extra_regs, NULL);
+
 		return current_reg + 1;
 	}
 	case AST_VALUE_FOREIGN:

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -109,6 +109,8 @@ typedef struct compiler_ins {
 typedef struct ins_builder {
 	compiler_ins_t* instructions;
 	uint16_t instruction_count, alloced_ins;
+
+	safe_gc_t* safe_gc;
 } ins_builder_t;
 
 typedef struct compiler {
@@ -127,13 +129,14 @@ typedef struct compiler {
 
 	uint16_t current_global;
 	
+	safe_gc_t* safe_gc;
 	error_t last_err;
 } compiler_t;
 
-int init_ins_builder(ins_builder_t* ins_builder);
+int init_ins_builder(ins_builder_t* ins_builder, safe_gc_t* safe_gc);
 int ins_builder_append_ins(ins_builder_t* ins_builder, compiler_ins_t ins);
 
-int compile(compiler_t* compiler, machine_t* target_machine, ast_t* ast);
+int compile(compiler_t* compiler, safe_gc_t* safe_gc, machine_t* target_machine, ast_t* ast);
 
 void compiler_ins_to_machine_ins(compiler_ins_t* compiler_ins, machine_ins_t* machine_ins, uint64_t ins_count);
 

--- a/src/error.c
+++ b/src/error.c
@@ -47,6 +47,7 @@ static void** find_entry(safe_gc_t* safe_gc, void* data) {
 
 void* safe_malloc(safe_gc_t* safe_gc, int size) {
 	void* data = malloc(size);
+
 	ESCAPE_ON_FAIL(data);
 
 	void** entry = new_entry(safe_gc);
@@ -77,6 +78,7 @@ void* safe_transfer_malloc(safe_gc_t* safe_gc, int size) {
 
 void* safe_calloc(safe_gc_t* safe_gc, int count, size_t size) {
 	void* data = calloc(count, size);
+
 	ESCAPE_ON_FAIL(data);
 
 	void** entry = new_entry(safe_gc);

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,124 @@
+#include <stdlib.h>
+#include "error.h"
+
+int init_safe_gc(safe_gc_t* safe_gc) {
+	ESCAPE_ON_FAIL(safe_gc->entries = malloc((safe_gc->alloced_entries = 25) * sizeof(void*)));
+	ESCAPE_ON_FAIL(safe_gc->availible_entries = malloc((safe_gc->alloced_availible_entries = 5) * sizeof(void**)));
+	ESCAPE_ON_FAIL(safe_gc->transfer_entries = malloc((safe_gc->alloced_transfer_entries = 5) * sizeof(void*)));
+	safe_gc->entry_count = 0;
+	safe_gc->avaible_entry_count = 0;
+	safe_gc->transfer_entry_count = 0;
+}
+
+void free_safe_gc(safe_gc_t* safe_gc, int free_transfers) {
+	for (uint_fast64_t i = 0; i < safe_gc->entry_count; i++) {
+		if (safe_gc->entries[i])
+			free(safe_gc->entries[i]);
+	}
+	if (free_transfers) {
+		for (uint_fast64_t i = 0; i < safe_gc->transfer_entry_count; i++)
+			free(safe_gc->transfer_entries[i]);
+	}
+	free(safe_gc->entries);
+	free(safe_gc->availible_entries);
+	free(safe_gc->transfer_entries);
+}
+
+static void** new_entry(safe_gc_t* safe_gc) {
+	if (safe_gc->avaible_entry_count)
+		return safe_gc->availible_entries[--safe_gc->avaible_entry_count];
+	else {
+		if (safe_gc->entry_count == safe_gc->alloced_entries) {
+			void** new_entries = realloc(safe_gc->entries, (safe_gc->alloced_entries += 10) * sizeof(void*));
+			ESCAPE_ON_FAIL(new_entries);
+			safe_gc->entries = new_entries;
+		}
+		return &safe_gc->entries[safe_gc->entry_count++];
+	}
+}
+
+static void** find_entry(safe_gc_t* safe_gc, void* data) {
+	ESCAPE_ON_FAIL(data);
+	for (uint_fast64_t i = 0; i < safe_gc->entry_count; i++)
+		if (safe_gc->entries[i] == data)
+			return &safe_gc->entries[i];
+	return NULL;
+}
+
+void* safe_malloc(safe_gc_t* safe_gc, int size) {
+	void* data = malloc(size);
+	ESCAPE_ON_FAIL(data);
+
+	void** entry = new_entry(safe_gc);
+	if (!entry) {
+		free(data);
+		return 0;
+	}
+	else {
+		*entry = data;
+		return data;
+	}
+}
+
+void* safe_transfer_malloc(safe_gc_t* safe_gc, int size) {
+	void* data = malloc(size);
+	ESCAPE_ON_FAIL(data);
+
+	if (safe_gc->transfer_entry_count == safe_gc->alloced_transfer_entries) {
+		void* new_transfer_entries = realloc(safe_gc->transfer_entries, (safe_gc->alloced_transfer_entries += 2) * sizeof(void*));
+		if (!new_transfer_entries) {
+			free(data);
+			return NULL;
+		}
+		safe_gc->transfer_entries = new_transfer_entries;
+	}
+	return safe_gc->transfer_entries[safe_gc->transfer_entry_count++] = data;
+}
+
+void* safe_calloc(safe_gc_t* safe_gc, int count, size_t size) {
+	void* data = calloc(count, size);
+	ESCAPE_ON_FAIL(data);
+
+	void** entry = new_entry(safe_gc);
+	if (!entry) {
+		free(data);
+		return 0;
+	}
+	else {
+		*entry = data;
+		return data;
+	}
+}
+
+void* safe_add_managed(safe_gc_t* safe_gc, void* alloc) {
+	ESCAPE_ON_FAIL(alloc);
+
+	void** entry = new_entry(safe_gc);
+	ESCAPE_ON_FAIL(entry);
+
+	*entry = alloc;
+	return alloc;
+}
+
+void* safe_realloc(safe_gc_t* safe_gc, void* data, int new_size) {
+	void** entry = find_entry(safe_gc, data);
+	ESCAPE_ON_FAIL(entry);
+	ESCAPE_ON_FAIL(data = realloc(data, new_size));
+	*entry = data;
+	return data;
+}
+
+int safe_free(safe_gc_t* safe_gc, void* data) {
+	void** entry = find_entry(safe_gc, data);
+	ESCAPE_ON_FAIL(entry);
+	free(data);
+	*entry = NULL;
+	
+	if (safe_gc->avaible_entry_count == safe_gc->alloced_availible_entries) {
+		void*** new_availible_entries = realloc(safe_gc->availible_entries, (safe_gc->alloced_availible_entries += 5) * sizeof(void**));
+		ESCAPE_ON_FAIL(new_availible_entries);
+		safe_gc->availible_entries = new_availible_entries;
+	}
+	safe_gc->availible_entries[safe_gc->avaible_entry_count++] = entry;
+	return 1;
+}

--- a/src/error.h
+++ b/src/error.h
@@ -3,6 +3,7 @@
 #ifndef ERROR_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 typedef enum error {
 	ERROR_NONE,
@@ -41,8 +42,28 @@ typedef enum error {
 	ERROR_CANNOT_OPEN_FILE
 } error_t;
 
+typedef struct safe_gc {
+	void** entries;
+	void*** availible_entries;
+
+	void** transfer_entries;
+
+	uint64_t entry_count, alloced_entries, avaible_entry_count, alloced_availible_entries, transfer_entry_count, alloced_transfer_entries;
+} safe_gc_t;
+
 #define PANIC(OBJ, ERROR){ OBJ->last_err = ERROR; return 0; }
 #define ESCAPE_ON_FAIL(PTR) {if(!(PTR)) { return 0; }}
 #define PANIC_ON_FAIL(PTR, OBJ, ERROR) {if(!(PTR)) PANIC(OBJ, ERROR)}
+
+int init_safe_gc(safe_gc_t* safe_gc);
+void free_safe_gc(safe_gc_t* safe_gc, int free_transfers);
+
+void* safe_malloc(safe_gc_t* safe_gc, int size);
+void* safe_calloc(safe_gc_t* safe_gc, int count, size_t size);
+void* safe_realloc(safe_gc_t* safe_gc, void* ptr, int new_size);
+int safe_free(safe_gc_t* safe_gc, void* data);
+
+void* safe_transfer_malloc(safe_gc_t* safe_gc, int size);
+void* safe_add_managed(safe_gc_t* safe_gc, void* alloc);
 
 #endif // !ERROR_H

--- a/src/machine.c
+++ b/src/machine.c
@@ -179,7 +179,7 @@ int init_machine(machine_t* machine, uint16_t stack_size, uint16_t frame_limit, 
 }
 
 static void free_defined_signature(machine_type_sig_t* type_sig) {
-	if (type_sig->super_signature >= TYPE_SUPER_PROC) {
+	if (type_sig->super_signature >= TYPE_SUPER_PROC && type_sig->sub_type_count) {
 		for (uint_fast8_t i = 0; i < type_sig->sub_type_count; i++)
 			free_defined_signature(&type_sig->sub_types[i]);
 		free(type_sig->sub_types);

--- a/src/machine.c
+++ b/src/machine.c
@@ -220,6 +220,10 @@ machine_type_sig_t* new_type_sig(machine_t* machine) {
 int machine_execute(machine_t* machine, machine_ins_t* instructions) {
 	machine_ins_t* ip = instructions;
 	for (;;) {
+		if (ip - instructions == 69) {//165) {
+			int sadd = 23;
+		}
+
 		switch (ip->op_code) {
 		case MACHINE_OP_CODE_MOVE_LL:
 			machine->stack[ip->a + machine->global_offset] = machine->stack[ip->b + machine->global_offset];
@@ -460,10 +464,10 @@ int machine_execute(machine_t* machine, machine_ins_t* instructions) {
 			break;
 		}
 		case MACHINE_OP_CODE_DYNAMIC_CONF_LL:
-			machine->stack[ip->a + machine->global_offset].heap_alloc->trace_stat[ip->b] = machine->stack[ip->c + machine->global_offset].long_int >= TYPE_SUPER_ARRAY;
+			machine->stack[ip->a + machine->global_offset].heap_alloc->trace_stat[ip->b] = machine->defined_signatures[machine->stack[ip->c + machine->global_offset].long_int].super_signature >= TYPE_SUPER_ARRAY;
 			break;
 		case MACHINE_OP_CODE_DYNAMIC_CONF_ALL_LL:
-			machine->stack[ip->a + machine->global_offset].heap_alloc->trace_mode = machine->stack[ip->b + machine->global_offset].long_int >= TYPE_SUPER_ARRAY;
+			machine->stack[ip->a + machine->global_offset].heap_alloc->trace_mode = machine->defined_signatures[machine->stack[ip->b + machine->global_offset].long_int].super_signature >= TYPE_SUPER_ARRAY;
 			break;
 		case MACHINE_OP_CODE_CONF_TRACE_L:
 			machine->stack[ip->a + machine->global_offset].heap_alloc->trace_stat[ip->b] = ip->c;
@@ -496,7 +500,7 @@ int machine_execute(machine_t* machine, machine_ins_t* instructions) {
 			MACHINE_ESCAPE_COND(machine->stack[ip->a].heap_alloc = machine_alloc(machine, ip->b, ip->c));
 			break;
 		case MACHINE_OP_CODE_DYNAMIC_FREE_LL:
-			if (!machine->stack[ip->b + machine->global_offset].long_int >= TYPE_SUPER_ARRAY)
+			if (!(machine->defined_signatures[machine->stack[ip->b + machine->global_offset].long_int].super_signature >= TYPE_SUPER_ARRAY))
 				break;
 		case MACHINE_OP_CODE_FREE_L:
 			MACHINE_ESCAPE_COND(free_alloc(machine, machine->stack[ip->a + machine->global_offset].heap_alloc));
@@ -515,7 +519,7 @@ int machine_execute(machine_t* machine, machine_ins_t* instructions) {
 			int super_traced;
 			heap_alloc_t* heap_alloc;
 		case MACHINE_OP_CODE_DYNAMIC_TRACE_LL:
-			if (!machine->stack[ip->b + machine->global_offset].long_int >= TYPE_SUPER_ARRAY)
+			if (!(machine->defined_signatures[machine->stack[ip->b + machine->global_offset].long_int].super_signature >= TYPE_SUPER_ARRAY))
 				break;
 			super_traced = 0;
 			heap_alloc = machine->stack[ip->a + machine->global_offset].heap_alloc;

--- a/src/postproc.c
+++ b/src/postproc.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include <string.h>
 #include "ast.h"
 #include "postproc.h"
@@ -292,26 +291,26 @@ static int ast_postproc_code_block(ast_parser_t* ast_parser, ast_code_block_t* c
 			ast_cond_t* current_cond = code_block->instructions[i].data.conditional;
 			while (current_cond) {
 				if (current_cond->condition)
-					ESCAPE_ON_FAIL(ast_postproc_value(ast_parser, current_cond->condition, trace_stats, is_top_level ? ast_parser->top_level_global_gc_stats : global_gc_stats, local_gc_stats, is_top_level ? ast_parser->shared_globals : shared_globals, shared_locals, local_scope_size, POSTPROC_PARENT_IRRELEVANT, parent_proc))
+					ESCAPE_ON_FAIL(ast_postproc_value(ast_parser, current_cond->condition, trace_stats, is_top_level ? ast_parser->top_level_global_gc_stats : global_gc_stats, local_gc_stats, is_top_level ? ast_parser->shared_globals : shared_globals, shared_locals, local_scope_size, POSTPROC_PARENT_IRRELEVANT, parent_proc));
 
-					postproc_gc_status_t* new_gc_context = malloc(local_scope_size * sizeof(postproc_gc_status_t));
+				postproc_gc_status_t* new_gc_context = safe_malloc(ast_parser->safe_gc, local_scope_size * sizeof(postproc_gc_status_t));
 				PANIC_ON_FAIL(new_gc_context, ast_parser, ERROR_MEMORY);
-				postproc_gc_status_t* new_global_stats = malloc(ast_parser->global_count * sizeof(postproc_gc_status_t));
+				postproc_gc_status_t* new_global_stats = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(postproc_gc_status_t));
 				PANIC_ON_FAIL(new_global_stats, ast_parser, ERROR_MEMORY);
 				memcpy(new_global_stats, is_top_level ? ast_parser->top_level_global_gc_stats : global_gc_stats, ast_parser->global_count * sizeof(postproc_gc_status_t));
-				int* new_shared_locals = malloc(local_scope_size * sizeof(int));
+				int* new_shared_locals = safe_malloc(ast_parser->safe_gc, local_scope_size * sizeof(int));
 				PANIC_ON_FAIL(new_shared_locals, ast_parser, ERROR_MEMORY);
-				int* new_shared_globals = malloc(ast_parser->global_count * sizeof(int));
+				int* new_shared_globals = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(int));
 				PANIC_ON_FAIL(new_shared_globals, ast_parser, ERROR_MEMORY);
 				memcpy(new_gc_context, local_gc_stats, local_scope_size * sizeof(postproc_gc_status_t));
 				memcpy(new_shared_locals, shared_locals, local_scope_size * sizeof(int));
 				memcpy(new_shared_globals, is_top_level ? ast_parser->shared_globals : shared_globals, ast_parser->global_count * sizeof(int));
 
 				ESCAPE_ON_FAIL(ast_postproc_code_block(ast_parser, &current_cond->exec_block, trace_stats, is_top_level ? ast_parser->top_level_global_gc_stats : new_global_stats, new_gc_context, local_scope_size, new_shared_globals, new_shared_locals, is_top_level, parent_proc));
-				free(new_gc_context);
-				free(new_global_stats);
-				free(new_shared_locals);
-				free(new_shared_globals);
+				safe_free(ast_parser->safe_gc, new_gc_context);
+				safe_free(ast_parser->safe_gc, new_global_stats);
+				safe_free(ast_parser->safe_gc, new_shared_locals);
+				safe_free(ast_parser->safe_gc, new_shared_globals);
 				current_cond = current_cond->next_if_false;
 			}
 			break;
@@ -418,13 +417,13 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		break;
 	case AST_VALUE_ALLOC_RECORD: {
 		PROC_DO_GC;
-		PANIC_ON_FAIL(value->data.alloc_record.typearg_traces = malloc((value->data.alloc_record.proto->index_offset + value->data.alloc_record.proto->property_count) * sizeof(postproc_trace_status_t)), ast_parser, ERROR_MEMORY);
+		PANIC_ON_FAIL(value->data.alloc_record.typearg_traces = safe_malloc(ast_parser->safe_gc, (value->data.alloc_record.proto->index_offset + value->data.alloc_record.proto->property_count) * sizeof(postproc_trace_status_t)), ast_parser, ERROR_MEMORY);
 
-		typecheck_type_t* current_typeargs = malloc(TYPE_MAX_SUBTYPES * sizeof(typecheck_type_t));
+		typecheck_type_t* current_typeargs = safe_malloc(ast_parser->safe_gc, TYPE_MAX_SUBTYPES * sizeof(typecheck_type_t));
 		PANIC_ON_FAIL(current_typeargs, ast_parser, ERROR_MEMORY);
 		memcpy(current_typeargs, value->type.sub_types, value->type.sub_type_count * sizeof(typecheck_type_t));
 
-		int* overriden_defaults = calloc((size_t)value->data.alloc_record.proto->index_offset + (size_t)value->data.alloc_record.proto->property_count, sizeof(int));
+		int* overriden_defaults = safe_calloc(ast_parser->safe_gc, (size_t)value->data.alloc_record.proto->index_offset + (size_t)value->data.alloc_record.proto->property_count, sizeof(int));
 		PANIC_ON_FAIL(overriden_defaults, ast_parser, ERROR_MEMORY);
 		for (uint_fast8_t i = 0; i < value->data.alloc_record.init_value_count; i++)
 			overriden_defaults[value->data.alloc_record.init_values[i].property->id] = 1;
@@ -436,17 +435,16 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 					overriden_defaults[current_proto->default_values[i].property->id] = 1;
 					if (value->data.alloc_record.init_value_count == value->data.alloc_record.allocated_init_values) {
 						if (value->data.alloc_record.allocated_init_values) {
-							struct ast_alloc_record_init_value* new_init_values = realloc(value->data.alloc_record.init_values, (value->data.alloc_record.allocated_init_values += 2) * sizeof(struct ast_alloc_record_init_value));
+							struct ast_alloc_record_init_value* new_init_values = safe_realloc(ast_parser->safe_gc, value->data.alloc_record.init_values, (value->data.alloc_record.allocated_init_values += 2) * sizeof(struct ast_alloc_record_init_value));
 							PANIC_ON_FAIL(new_init_values, ast_parser, ERROR_MEMORY);
 							value->data.alloc_record.init_values = new_init_values;
 						}
 						else
-							PANIC_ON_FAIL(value->data.alloc_record.init_values = malloc((value->data.alloc_record.allocated_init_values = 5) * sizeof(ast_alloc_record_init_value_t)), ast_parser, ERROR_MEMORY);
+							PANIC_ON_FAIL(value->data.alloc_record.init_values = safe_malloc(ast_parser->safe_gc, (value->data.alloc_record.allocated_init_values = 5) * sizeof(ast_alloc_record_init_value_t)), ast_parser, ERROR_MEMORY);
 					}
 					value->data.alloc_record.init_values[value->data.alloc_record.init_value_count++] = (ast_alloc_record_init_value_t){
 						.value = &current_proto->default_values[i].value,
-						.property = current_proto->default_values[i].property,
-						.free_val = 0
+						.property = current_proto->default_values[i].property
 					};
 				}
 
@@ -477,8 +475,8 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 			}
 			else break;
 		}
-		free(current_typeargs);
-		free(overriden_defaults);
+		safe_free(ast_parser->safe_gc, current_typeargs);
+		safe_free(ast_parser->safe_gc, overriden_defaults);
 
 		for (uint_fast16_t i = 0; i < value->data.alloc_record.init_value_count; i++) {
 			ESCAPE_ON_FAIL(ast_postproc_value(ast_parser, value->data.alloc_record.init_values[i].value, value->data.alloc_record.typearg_traces, global_gc_stats, local_gc_stats, shared_globals, shared_locals, local_scope_size, parent_stat, parent_proc));
@@ -492,17 +490,17 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		value->trace_status = POSTPROC_TRACE_NONE;
 		value->gc_status = POSTPROC_GC_NONE;
 
-		postproc_gc_status_t* new_local_stats = malloc(value->data.procedure->scope_size * sizeof(postproc_gc_status_t));
+		postproc_gc_status_t* new_local_stats = safe_malloc(ast_parser->safe_gc, value->data.procedure->scope_size * sizeof(postproc_gc_status_t));
 		PANIC_ON_FAIL(new_local_stats, ast_parser, ERROR_MEMORY);
-		postproc_gc_status_t* new_global_stats = malloc(ast_parser->global_count * sizeof(int));
+		postproc_gc_status_t* new_global_stats = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(int));
 		PANIC_ON_FAIL(new_global_stats, ast_parser, ERROR_MEMORY);
 		memcpy(new_global_stats, ast_parser->global_gc_stats, ast_parser->global_count * sizeof(postproc_gc_status_t));
-		int* new_shared_locals = calloc(value->data.procedure->scope_size, sizeof(int));
+		int* new_shared_locals = safe_calloc(ast_parser->safe_gc, value->data.procedure->scope_size, sizeof(int));
 		PANIC_ON_FAIL(new_shared_locals, ast_parser, ERROR_MEMORY);
-		int* new_shared_globals = malloc(ast_parser->global_count * sizeof(int));
+		int* new_shared_globals = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(int));
 		PANIC_ON_FAIL(new_shared_globals, ast_parser, ERROR_MEMORY);
 		memcpy(new_shared_globals, ast_parser->shared_globals, ast_parser->global_count * sizeof(int));
-		value->data.procedure->generic_arg_traces = malloc(value->type.type_id * sizeof(postproc_trace_status_t));
+		value->data.procedure->generic_arg_traces = safe_malloc(ast_parser->safe_gc, value->type.type_id * sizeof(postproc_trace_status_t));
 		PANIC_ON_FAIL(value->data.procedure->generic_arg_traces, ast_parser, ERROR_MEMORY);
 
 		for (uint_fast8_t i = 0; i < value->type.type_id; i++) {
@@ -524,10 +522,10 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		value->data.procedure->do_gc = 0;
 		ESCAPE_ON_FAIL(ast_postproc_code_block(ast_parser, &value->data.procedure->exec_block, value->data.procedure->generic_arg_traces, new_global_stats, new_local_stats, value->data.procedure->scope_size, new_shared_globals, new_shared_locals, 0, value->data.procedure));
 
-		free(new_local_stats);
-		free(new_global_stats);
-		free(new_shared_locals);
-		free(new_shared_globals);
+		safe_free(ast_parser->safe_gc, new_local_stats);
+		safe_free(ast_parser->safe_gc, new_global_stats);
+		safe_free(ast_parser->safe_gc, new_shared_locals);
+		safe_free(ast_parser->safe_gc, new_shared_globals);
 		break;
 	}
 	case AST_VALUE_VAR:
@@ -641,7 +639,7 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		ESCAPE_ON_FAIL(ast_postproc_value(ast_parser, &value->data.get_prop->record, typearg_traces, global_gc_stats, local_gc_stats, shared_globals, shared_locals, local_scope_size, GET_TYPE_TRACE(prop_type) == POSTPROC_TRACE_NONE ? POSTPROC_PARENT_IRRELEVANT : parent_stat, parent_proc));
 		value->gc_status = postproc_type_to_gc_stat(value->data.get_prop->record.gc_status, prop_type.type);
 		value->from_var = value->data.get_prop->record.from_var;
-		free_typecheck_type(&prop_type);
+		free_typecheck_type(ast_parser->safe_gc, &prop_type);
 		break;
 	}
 	case AST_VALUE_BINARY_OP:
@@ -666,7 +664,7 @@ static int ast_postproc_value(ast_parser_t* ast_parser, ast_value_t* value, post
 		break;
 	case AST_VALUE_PROC_CALL:
 		ESCAPE_ON_FAIL(ast_postproc_value(ast_parser, &value->data.proc_call->procedure, typearg_traces, global_gc_stats, local_gc_stats, shared_globals, shared_locals, local_scope_size, POSTPROC_PARENT_IRRELEVANT, parent_proc));
-		PANIC_ON_FAIL(value->data.proc_call->typearg_traces = malloc(value->data.proc_call->procedure.type.type_id * sizeof(postproc_trace_status_t)), ast_parser, ERROR_MEMORY);
+		PANIC_ON_FAIL(value->data.proc_call->typearg_traces = safe_malloc(ast_parser->safe_gc, value->data.proc_call->procedure.type.type_id * sizeof(postproc_trace_status_t)), ast_parser, ERROR_MEMORY);
 		if (value->data.proc_call->procedure.type.type_id) {
 			for (uint_fast8_t i = 0; i < value->data.proc_call->procedure.type.type_id; i++)
 				if (value->data.proc_call->typeargs[i].type == TYPE_TYPEARG)
@@ -769,21 +767,21 @@ int ast_postproc(ast_parser_t* ast_parser) {
 	while (ast_postproc_codeblock_affects_state(&ast_parser->ast->exec_block, 0)) {}
 
 	//allocate memory used for analysis
-	PANIC_ON_FAIL(ast_parser->top_level_global_gc_stats = malloc(ast_parser->global_count * sizeof(postproc_gc_status_t)), ast_parser, ERROR_MEMORY);
-	PANIC_ON_FAIL(ast_parser->global_gc_stats = malloc(ast_parser->global_count * sizeof(postproc_gc_status_t)), ast_parser, ERROR_MEMORY);
-	postproc_gc_status_t* top_level_locals = malloc(ast_parser->top_level_local_count * sizeof(postproc_gc_status_t));
+	PANIC_ON_FAIL(ast_parser->top_level_global_gc_stats = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(postproc_gc_status_t)), ast_parser, ERROR_MEMORY);
+	PANIC_ON_FAIL(ast_parser->global_gc_stats = safe_malloc(ast_parser->safe_gc, ast_parser->global_count * sizeof(postproc_gc_status_t)), ast_parser, ERROR_MEMORY);
+	postproc_gc_status_t* top_level_locals = safe_malloc(ast_parser->safe_gc, ast_parser->top_level_local_count * sizeof(postproc_gc_status_t));
 	PANIC_ON_FAIL(top_level_locals, ast_parser, ERROR_MEMORY);
-	PANIC_ON_FAIL(ast_parser->shared_globals = calloc(ast_parser->global_count, sizeof(int)), ast_parser, ERROR_MEMORY);
-	int* shared_top_level = calloc(ast_parser->top_level_local_count, sizeof(int));
+	PANIC_ON_FAIL(ast_parser->shared_globals = safe_calloc(ast_parser->safe_gc, ast_parser->global_count, sizeof(int)), ast_parser, ERROR_MEMORY);
+	int* shared_top_level = safe_calloc(ast_parser->safe_gc, ast_parser->top_level_local_count, sizeof(int));
 	PANIC_ON_FAIL(shared_top_level, ast_parser, ERROR_MEMORY);
 	ESCAPE_ON_FAIL(ast_postproc_code_block(ast_parser, &ast_parser->ast->exec_block, NULL, NULL, top_level_locals, ast_parser->top_level_local_count, NULL, shared_top_level, 1, NULL));
 
 	while (ast_postproc_codeblock_affects_state(&ast_parser->ast->exec_block, 1)) {}
 
-	free(shared_top_level);
-	free(top_level_locals);
-	free(ast_parser->shared_globals);
-	free(ast_parser->global_gc_stats);
-	free(ast_parser->top_level_global_gc_stats);
+	safe_free(ast_parser->safe_gc, shared_top_level);
+	safe_free(ast_parser->safe_gc, top_level_locals);
+	safe_free(ast_parser->safe_gc, ast_parser->shared_globals);
+	safe_free(ast_parser->safe_gc, ast_parser->global_gc_stats);
+	safe_free(ast_parser->safe_gc, ast_parser->top_level_global_gc_stats);
 	return 1;
 }

--- a/src/postproc.h
+++ b/src/postproc.h
@@ -3,6 +3,8 @@
 #ifndef POSTPROC_H
 #define POSTPROC_H
 
+#include "error.h"
+
 typedef struct ast_parser ast_parser_t;
 
 typedef enum postproc_gc_status {

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -28,6 +28,8 @@ typedef struct multi_scanner {
 
 	token_t last_tok;
 	error_t last_err;
+
+	safe_gc_t* safe_gc;
 } multi_scanner_t;
 
 void init_scanner(scanner_t* scanner, const char* source, uint32_t length);
@@ -35,8 +37,7 @@ void init_scanner(scanner_t* scanner, const char* source, uint32_t length);
 int scanner_scan_char(scanner_t* scanner);
 int scanner_scan_tok(scanner_t* scanner);
 
-int init_multi_scanner(multi_scanner_t* scanner, const char* path);
-void free_multi_scanner(multi_scanner_t* scanner);
+int init_multi_scanner(multi_scanner_t* scanner, safe_gc_t* safe_gc, const char* path);
 int multi_scanner_visit(multi_scanner_t* scanner, const char* file);
 int multi_scanner_scan_tok(multi_scanner_t* scanner);
 

--- a/src/source.c
+++ b/src/source.c
@@ -24,33 +24,39 @@ int main(int argc, char* argv[]) {
 	const char* op_flag = READ_ARG;
 
 	if (!strcmp(op_flag, "-cr") || !strcmp(op_flag, "-c") || !strcmp(op_flag, "-cd")) {
+		safe_gc_t safe_gc;
+		if (!init_safe_gc(&safe_gc))
+			ABORT(("Error initializing safe-gc."));
+
 		ast_parser_t parser;
 		EXPECT_FLAG("-s");
-		if (!init_ast_parser(&parser, READ_ARG))
+		if (!init_ast_parser(&parser, &safe_gc, READ_ARG)) {
+			free_safe_gc(&safe_gc, 1);
 			ABORT(("Error initializing parser(%s).\n", get_err_msg(parser.last_err)));
+		}
+
 		ast_t ast;
 		if (!init_ast(&ast, &parser)) {
+			free_safe_gc(&safe_gc, 1);
 			print_error_trace(parser.multi_scanner);
 			ABORT(("Syntax error(%s).\n", get_err_msg(parser.last_err)));
 		}
 
 		machine_t machine;
 		compiler_t compiler;
-		if (!compile(&compiler, &machine, &ast))
+		if (!compile(&compiler, &safe_gc, &machine, &ast)) {
+			free_safe_gc(&safe_gc, 1);
 			ABORT(("Compilation failiure(%s).\n", get_err_msg(compiler.last_err)));
+		}
 
 		machine_ins_t* machine_ins = malloc(compiler.ins_builder.instruction_count * sizeof(machine_ins_t));
-		if(!machine_ins)
+		if (!machine_ins) {
+			free_safe_gc(&safe_gc, 1);
 			ABORT(("Compilation failiure(memory).\n"));
+		}
 
 		compiler_ins_to_machine_ins(compiler.ins_builder.instructions, machine_ins, compiler.ins_builder.instruction_count);
-		free(compiler.ins_builder.instructions);
-
-		free_ast_parser(&parser);
-		free_ast(&ast);
-
-
-		print_instructions(machine_ins, compiler.ins_builder.instruction_count);
+		free_safe_gc(&safe_gc, 0);
 
 		if (!strcmp(op_flag, "-cr")) {
 			if (!install_stdlib(&machine))

--- a/src/source.c
+++ b/src/source.c
@@ -8,6 +8,7 @@
 #include "file.h"
 #include "stdlibf.h"
 #include "debug.h"
+#include "error.h"
 
 #define ABORT(MSG) {printf MSG ; exit(EXIT_FAILURE);}
 
@@ -57,6 +58,8 @@ int main(int argc, char* argv[]) {
 
 		compiler_ins_to_machine_ins(compiler.ins_builder.instructions, machine_ins, compiler.ins_builder.instruction_count);
 		free_safe_gc(&safe_gc, 0);
+		
+		print_instructions(machine_ins, compiler.ins_builder.instruction_count);
 
 		if (!strcmp(op_flag, "-cr")) {
 			if (!install_stdlib(&machine))

--- a/src/source.c
+++ b/src/source.c
@@ -37,8 +37,8 @@ int main(int argc, char* argv[]) {
 
 		ast_t ast;
 		if (!init_ast(&ast, &parser)) {
-			free_safe_gc(&safe_gc, 1);
 			print_error_trace(parser.multi_scanner);
+			free_safe_gc(&safe_gc, 1);
 			ABORT(("Syntax error(%s).\n", get_err_msg(parser.last_err)));
 		}
 

--- a/src/source.c
+++ b/src/source.c
@@ -58,8 +58,6 @@ int main(int argc, char* argv[]) {
 
 		compiler_ins_to_machine_ins(compiler.ins_builder.instructions, machine_ins, compiler.ins_builder.instruction_count);
 		free_safe_gc(&safe_gc, 0);
-		
-		print_instructions(machine_ins, compiler.ins_builder.instruction_count);
 
 		if (!strcmp(op_flag, "-cr")) {
 			if (!install_stdlib(&machine))

--- a/src/type.h
+++ b/src/type.h
@@ -4,6 +4,7 @@
 #define TYPE_H
 
 #include <stdint.h>
+#include "error.h"
 
 #define TYPE_MAX_SUBTYPES 100
 
@@ -47,14 +48,14 @@ static typecheck_type_t typecheck_float = { .type = TYPE_PRIMITIVE_FLOAT };
 static typecheck_type_t typecheck_any = { .type = TYPE_ANY };
 static typecheck_type_t typecheck_array = { .type = TYPE_SUPER_ARRAY, .sub_type_count = 1, .sub_types = &typecheck_any };
 
-void free_typecheck_type(typecheck_type_t* typecheck_type);
-int copy_typecheck_type(typecheck_type_t* dest, typecheck_type_t src);
+void free_typecheck_type(safe_gc_t* safe_gc, typecheck_type_t* typecheck_type);
+int copy_typecheck_type(safe_gc_t* safe_gc, typecheck_type_t* dest, typecheck_type_t src);
 
 int typecheck_compatible(ast_parser_t* ast_parser, typecheck_type_t* target_type, typecheck_type_t match_type);
 
 int typecheck_has_type(typecheck_type_t type, typecheck_base_type_t base_type);
 
-int typeargs_substitute(typecheck_type_t* input_typeargs, typecheck_type_t* proto_type);
+int typeargs_substitute(safe_gc_t* safe_gc, typecheck_type_t* input_typeargs, typecheck_type_t* proto_type);
 int typecheck_lowest_common_type(ast_parser_t* ast_parser, typecheck_type_t a, typecheck_type_t b, typecheck_type_t* result);
 
 ast_generic_cache_entry_t* generic_from_type(ast_parser_t* ast_parser, typecheck_type_t type);


### PR DESCRIPTION
Previously, the compiler would leak memory *only upon an error* because of the way error-handling was implemented.

Namely every function returned an integer, one for success and zero for failure. In addition, an `ESCAPE_ON_FAIL` macro was employed to simplify the error handling to just one line: it functioned much like an assert that expected 1, but instead of panicking, it would merely return zero instead. It expanded into something like this:
```
if(!(EVAL) {
  return 0;
}
```
The problem with this however, was that no clean-up code was ever implemented. If a memory allocation was made earlier in the code, and the function returned pre-maturely because of a panic, the allocation made would never get cleaned up because any potential clean-up code after the `ESCAPE_ON_FAIL` would never be reached. Take this for example:
```
void* myMem = malloc(size);
ESCAPE_ON_FAIL(aFunctionThatCANNOTFail());
free(myMem);
```
If `aFunctionThatCANNOTFail` fails, `free(myMem)` would never execute.

At the time at least, this phenomenon was simply regarded as a trade-off for the relatively less complex error handling mechanism. The only requirements at for SuperForth, regarding memory, at the time were:
- SuperForth programs do not leak memory in code that is executed many times *repetitively*. This in turn was interpreted as:
  - The runtime should never leak memory. It never has, and never will.
  - The compiler may leak memory in limited circumstances because it is a one-time operation. 
    - Ultimately the compiler doesn't leak memory when it compiles a program succesfully.

However, now that one of my other projects([TeleClassic](https://github.com/TheRealMichaelWang/TeleClassic) is leveraging many instances of SuperForth that run user-inputted code, compiler memory leaks are treated very seriously because it is no longer a one-time operation.

Therefore the solution was to implement the "safe-gc", a mechanism that pushes all memory allocations made onto a stack that could be cleaned up afterwards, regardless of whether a function succeeded or failed. This new soloution not only works 100% of the time, but still promotes the same low-complexity error-handling style.